### PR TITLE
Revert "Enhanced & Refactored Home Page Components"

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ function Footer() {
     <div className="mt-40 flex w-full flex-col bg-footer-shadow pb-6 pt-6">
       <div className="mb-4 flex w-full flex-wrap items-center justify-between md:flex-nowrap">
         {/* gatech logo */}
-        <div className="py-4 font-bayon text-3xl tracking-wide flex w-full justify-center md:justify-start md:pl-10">
+        <div className="ml-10 py-4 font-bayon text-3xl tracking-wide">
           <Link to="/home" className="flex items-center">
             <img
               src={Logo}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -61,7 +61,7 @@ function Navbar() {
 
   return (
     <div
-      className={`fixed flex z-10 w-full h-[--navbar-height] pt-8 border-0 items-center justify-between bg-transparent md:flex md:px-20 md:py-6 transition-all duration-500 ${
+      className={`fixed flex z-10 w-full h-[--navbar-height] border-0 items-center justify-between bg-transparent md:flex md:px-20 md:py-6 transition-all duration-500 ${
         isScrolled ? "bg-opacity-70 backdrop-blur-md" : "bg-transparent"
       }`}
     >

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -55,7 +55,7 @@ function Home() {
 
   return (
     <div className="flex w-full flex-col bg-streak bg-cover">
-      <div className="flex min-h-screen items-center justify-center rounded-sm bg-home-1 bg-cover pt-16 pb-16 sm:pt-0 sm:pb-0">
+      <div className="flex min-h-screen items-center justify-center rounded-sm bg-home-1 bg-cover">
         <div className="flex flex-col items-center gap-4">
           <h1 className="px-3 py-3 font-bayon text-9xl font-normal text-tech-gold xs:rounded-lg xs:text-5xl xs:backdrop-blur-lg sm:text-7xl md:text-8xl lg:text-9xl">
             G<span className="text-white">eorgi</span>a Tech{" "}


### PR DESCRIPTION
Reverts gt-esports/gamefest#36

Refer to gatechesports.com

negatively affects bigger window sizes

Current Look (from this branch):
![image](https://github.com/user-attachments/assets/44f570cb-2542-4e06-bb8b-7d7a316866dc)
![image](https://github.com/user-attachments/assets/7622ecb4-e928-431d-809c-3e22d1cea5cc)

Desired Look:
![image](https://github.com/user-attachments/assets/35a1ef5e-6734-4111-a3e9-0eecfe69b7e4)
![image](https://github.com/user-attachments/assets/15819c4d-4c00-40a3-bab6-0439adfa7997)
(center the logo in mobile screen sizes)
