### PR TITLE
Feat: Check in feature for signed in and registered participants

### DIFF
--- a/src/hooks/useRegistration.ts
+++ b/src/hooks/useRegistration.ts
@@ -32,6 +32,7 @@ export const createRegistration = async (
       admission_type: input.admission_type,
       school: input.school?.trim() || null,
       heard_from: input.heard_from?.trim() || null,
+      checked_in: input.checked_in ?? false,
     })
     .select("*")
     .single();
@@ -40,15 +41,33 @@ export const createRegistration = async (
   return data as Registration;
 };
 
+export const checkInRegistration = async (
+  userId: string
+): Promise<Registration> => {
+  const { data, error } = await supabase
+    .from("registrations")
+    .update({ checked_in: true })
+    .eq("user_id", userId)
+    .select("*")
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) throw new Error("Registration not found");
+  return data as Registration;
+};
+
 export const useRegistration = (userId: string | null) => {
   const [registration, setRegistration] = useState<Registration | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [checkingIn, setCheckingIn] = useState(false);
+  const [checkInError, setCheckInError] = useState<Error | null>(null);
 
   const refresh = useCallback(async () => {
     if (!userId) {
       setRegistration(null);
       setLoading(false);
+      setCheckInError(null);
       return;
     }
 
@@ -80,5 +99,35 @@ export const useRegistration = (userId: string | null) => {
     [userId, refresh]
   );
 
-  return { registration, loading, error, refresh, register };
+  const checkIn = useCallback(async () => {
+    if (!userId) throw new Error("Must be signed in to check in");
+
+    setCheckingIn(true);
+    setCheckInError(null);
+
+    try {
+      const reg = await checkInRegistration(userId);
+      setRegistration(reg);
+      await refresh();
+      return reg;
+    } catch (err) {
+      const nextError =
+        err instanceof Error ? err : new Error("Failed to check in");
+      setCheckInError(nextError);
+      throw nextError;
+    } finally {
+      setCheckingIn(false);
+    }
+  }, [userId, refresh]);
+
+  return {
+    registration,
+    loading,
+    error,
+    refresh,
+    register,
+    checkIn,
+    checkingIn,
+    checkInError,
+  };
 };

--- a/src/pages/RegistrationPage.tsx
+++ b/src/pages/RegistrationPage.tsx
@@ -12,7 +12,9 @@ const labelClass = "mb-1 block text-sm text-gray-300";
 
 const RegistrationPage = () => {
   const { isLoaded, user } = useUser();
-  const { registration, loading, register } = useRegistration(user?.id ?? null);
+  const { registration, loading, register, checkIn, checkingIn, checkInError } = useRegistration(
+    user?.id ?? null
+  );
   const navigate = useNavigate();
 
   const [form, setForm] = useState<CreateRegistrationInput>({
@@ -44,6 +46,14 @@ const RegistrationPage = () => {
       setSubmitError(err instanceof Error ? err.message : "Registration failed. Please try again.");
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleCheckIn = async () => {
+    try {
+      await checkIn();
+    } catch {
+      // Error state is handled by the hook.
     }
   };
 
@@ -82,6 +92,27 @@ const RegistrationPage = () => {
                 {registration.school && <Row label="School" value={registration.school} />}
                 {registration.heard_from && <Row label="Heard From" value={registration.heard_from} />}
               </div>
+              {registration.checked_in ? (
+                <p className="mt-6 rounded-lg border border-[#0099BB]/40 bg-[#0099BB]/10 px-4 py-3 text-sm text-[#7dd3f0]">
+                  <span className="font-semibold text-white">You&apos;re checked in!</span> Welcome to Gamefest!
+                </p>
+              ) : (
+                <div className="mt-6">
+                  <button
+                    type="button"
+                    onClick={() => void handleCheckIn()}
+                    disabled={checkingIn}
+                    className="w-full rounded bg-gradient-to-r from-[#004466] to-[#0099BB] py-3 font-bayon text-lg text-white hover:shadow-lg hover:shadow-[#0099BB]/50 disabled:opacity-50"
+                  >
+                    {checkingIn ? "CHECKING IN..." : "CHECK IN"}
+                  </button>
+                  {checkInError && (
+                    <p className="mt-3 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+                      {checkInError.message}
+                    </p>
+                  )}
+                </div>
+              )}
               <button
                 type="button"
                 onClick={() => navigate("/profile")}

--- a/src/schemas/RegistrationSchema.ts
+++ b/src/schemas/RegistrationSchema.ts
@@ -10,6 +10,7 @@ export type Registration = {
   school: string | null;
   heard_from: string | null;
   created_at: string;
+  checked_in: boolean;
 };
 
 export type CreateRegistrationInput = {
@@ -19,4 +20,5 @@ export type CreateRegistrationInput = {
   admission_type: AdmissionType;
   school?: string | null;
   heard_from?: string | null;
+  checked_in?: boolean;
 };

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -115,6 +115,7 @@ export interface Database {
           school: string | null;
           heard_from: string | null;
           created_at: string;
+          checked_in: boolean;
         };
         Insert: {
           id?: string;
@@ -126,6 +127,7 @@ export interface Database {
           school?: string | null;
           heard_from?: string | null;
           created_at?: string;
+          checked_in?: boolean;
         };
         Update: {
           id?: string;
@@ -137,6 +139,7 @@ export interface Database {
           school?: string | null;
           heard_from?: string | null;
           created_at?: string;
+          checked_in?: boolean;
         };
         Relationships: [
           {

--- a/supabase_scripts/04_registrations_table.sql
+++ b/supabase_scripts/04_registrations_table.sql
@@ -9,6 +9,7 @@ create table if not exists public.registrations (
   school text,
   heard_from text,
   created_at timestamptz default now(),
+  checked_in boolean default false,
   unique (user_id)
 );
 


### PR DESCRIPTION
This pull request adds a self-service check-in feature for event registrations. It introduces a new `checked_in` field to the registration schema, updates the database and type definitions accordingly, and exposes a new check-in button on the registration page. Users can now check themselves in, and the UI reflects their check-in status.

**Database and Schema Updates:**

* Added a `checked_in` boolean column (defaulting to `false`) to the `registrations` table in the Supabase schema.
* Updated type definitions and schemas (`Registration`, `CreateRegistrationInput`, and Supabase types) to include the new `checked_in` field. [[1]](diffhunk://#diff-f2ecdfc80d80dc2a148a2be3ff57eb502db0298c600f1007b212727d7e664080R13) [[2]](diffhunk://#diff-f2ecdfc80d80dc2a148a2be3ff57eb502db0298c600f1007b212727d7e664080R23) [[3]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R118) [[4]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R130) [[5]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R142)

**Backend Logic:**

* Modified the registration creation logic to set `checked_in` to `false` by default if not provided.
* Added a new `checkInRegistration` function to update the `checked_in` status for a user.

**Frontend Logic and UI:**

* Extended the `useRegistration` hook to expose `checkIn`, `checkingIn`, and `checkInError` state, and to handle check-in requests.
* Updated the registration page to show a check-in button if the user is not checked in, and a confirmation message if they are. The UI also handles loading and error states for check-in. [[1]](diffhunk://#diff-7c4f0bb570a69c461eac3610a4824b8ad3c59301a6e5c007e291416be642362aL15-R17) [[2]](diffhunk://#diff-7c4f0bb570a69c461eac3610a4824b8ad3c59301a6e5c007e291416be642362aR52-R59) [[3]](diffhunk://#diff-7c4f0bb570a69c461eac3610a4824b8ad3c59301a6e5c007e291416be642362aR95-R115)